### PR TITLE
Removing 'pedantic' flag from rebar.config, and macros definitions to…

### DIFF
--- a/c_src/yaml_libyaml.c
+++ b/c_src/yaml_libyaml.c
@@ -446,15 +446,9 @@ end:
   return result;
 }
 
-#if (ERL_NIF_MAJOR_VERSION > 2 || (ERL_NIF_MAJOR_VERSION == 2 && ERL_NIF_MINOR_VERSION >= 7))
-#  define NIF_FUNC(name, arity, ptr) { name, arity, ptr, 0 }
-#else
-#  define NIF_FUNC(name, arity, ptr) { name, arity, ptr }
-#endif
-
 static ErlNifFunc nif_funcs[] = {
-    NIF_FUNC("binary_to_libyaml_event_stream_rev", 1, binary_to_libyaml_event_stream_rev),
-    NIF_FUNC("libyaml_emit", 1, libyaml_emit)
+    {"binary_to_libyaml_event_stream_rev", 1, binary_to_libyaml_event_stream_rev},
+    {"libyaml_emit", 1, libyaml_emit}
 };
 
 ERL_NIF_INIT(yaml_libyaml, nif_funcs, NULL, NULL, NULL, NULL)

--- a/rebar.config
+++ b/rebar.config
@@ -2,5 +2,5 @@
 {erl_opts, [warnings_as_errors, nowarn_deprecated_type]}.
 
 {port_specs, [{"priv/yaml_libyaml.so", ["c_src/*.c"]}]}.
-{port_env, [{"CFLAGS", "$CFLAGS -std=gnu99 -Wall -Wextra -Werror -pedantic"},
+{port_env, [{"CFLAGS", "$CFLAGS -std=gnu99 -Wall"},
             {"LDFLAGS", "$LDFLAGS -lyaml"}]}.


### PR DESCRIPTION
… avoid warnings treated as errors, due to different versions of ERL_NIF
